### PR TITLE
Filter out deleted files before formatting

### DIFF
--- a/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
+++ b/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
@@ -2,7 +2,7 @@
 set -e
 # Retrieve staged files
 STAGED_FILES_FILE=$(mktemp)
-git diff --cached --name-only > "${STAGED_FILES_FILE}"
+git diff --cached --name-only --diff-filter=d > "${STAGED_FILES_FILE}"
 # Process the files
 %s git-code-format:on-pre-commit -DstagedFilesFile=${STAGED_FILES_FILE} %s
 # Add the files to staging again in case they were modified by the process


### PR DESCRIPTION
Without the filter when committing if a file was deleted the plugin tries to format it and fails with the message:

`fatal: pathspec '<FILE>' did not match any files`

More info on the filter: https://git-scm.com/docs/git-diff#git-diff---diff-filterACDMRTUXB82308203