### PR TITLE
Fix #31 windows install-hooks error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ cmake-build-debug/
 # IntelliJ
 out/
 
+# Eclipse
+.classpath
+.project
+.settings/
+
 # JIRA plugin
 atlassian-ide-plugin.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <source.level>1.8</source.level>
     <org.apache.commons.io.version>2.6</org.apache.commons.io.version>
     <org.apache.commons.lang.version>3.9</org.apache.commons.lang.version>
+    <org.apache.commons.exec.version>1.3</org.apache.commons.exec.version>
     <maven-git-code-format.version>1.25</maven-git-code-format.version>
   </properties>
 
@@ -31,6 +32,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${org.apache.commons.lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>${org.apache.commons.exec.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>

--- a/src/main/java/com/cosium/code/format/maven/MavenEnvironment.java
+++ b/src/main/java/com/cosium/code/format/maven/MavenEnvironment.java
@@ -5,6 +5,7 @@ import com.cosium.code.format.executable.CommandRunException;
 import com.cosium.code.format.executable.CommandRunner;
 import com.cosium.code.format.executable.DefaultCommandRunner;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.commons.exec.OS;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,6 +18,7 @@ import static java.util.Objects.requireNonNull;
  * Created on 02/11/17.
  *
  * @author Reda.Housni-Alaoui
+ * @author Matt.Ruel
  */
 public class MavenEnvironment {
 
@@ -42,10 +44,11 @@ public class MavenEnvironment {
     log.get().debug("maven.home=" + mavenHome);
     Path bin = mavenHome.resolve("bin");
     Path executable;
+    String extension = OS.isFamilyWindows() ? ".cmd" : "";
     if (!debug) {
-      executable = bin.resolve("mvn");
+      executable = bin.resolve("mvn" + extension);
     } else {
-      executable = bin.resolve("mvnDebug");
+      executable = bin.resolve("mvnDebug" + extension);
     }
 
     try {
@@ -57,9 +60,9 @@ public class MavenEnvironment {
 
     Path fallbackExecutable;
     if (!debug) {
-      fallbackExecutable = Paths.get("mvn");
+      fallbackExecutable = Paths.get("mvn" + extension);
     } else {
-      fallbackExecutable = Paths.get("mvnDebug");
+      fallbackExecutable = Paths.get("mvnDebug" + extension);
     }
 
     log.get()


### PR DESCRIPTION
On windows machine install-hooks fails with this error:

[ERROR] Failed to execute goal com.cosium.code:maven-git-code-format:1.38:install-hooks (install-formatter-hook) on project xyz: java.io.IOException: Cannot run program "C:\...\maven\bin\mvn": CreateProcess error=193, %1 is not a valid Win32 application

This fixes the error by looking for mvn.cmd instead of mvn if OS is windows.