### PR TITLE
Add pre-commit hook pipeline parameter to install-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,55 +91,6 @@ Documentation from the google-java-format CLI tool :
   Do not remove unused imports. Imports will still be sorted.
 ```
 
-### Advanced profile
-If you wish to install the pre-commit hook only if it is missing, you can use the following profile :
-```xml
-<profiles>
-  <profile>
-    <!-- Install pre-commit hook if missing-->
-    <id>install-pre-commit-hook</id>
-    <activation>
-      <file>
-        <missing>.git/hooks/pre-commit</missing>
-      </file>
-    </activation>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>com.cosium.code</groupId>
-          <artifactId>maven-git-code-format</artifactId>
-          <executions>
-            <execution>
-              <id>install-hook</id>
-              <goals>
-                <goal>install-hooks</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
-  </profile>
-</profiles>
-```
-
-### Advanced pre-commit pipeline hook
-If you wish to modify the output of the pre-commit hook, you can set the `preCommitHookPipeline` configuration.
-
-To completely ignore the hook output, you could use the following configuration:
-```xml
-      <configuration>
-        <preCommitHookPipeline>&gt;/dev/null</preCommitHookPipeline>
-      </configuration>
-```
-
-To display error lines from the maven output and fail build with any errors, you could use the following configuration:
-```xml
-      <configuration>
-        <preCommitHookPipeline>| grep -F '[ERROR]' || exit 0 &amp;&amp; exit 1</preCommitHookPipeline>
-      </configuration>
-```
-
 ### Frequently asked questions
 
 #### If I have a multi-module project, do I need to install anything in the sub-projects?
@@ -167,3 +118,20 @@ set -e
 ```
 
 On `pre-commit` git phase, the hook triggers the `git-code-format:on-pre-commit` which formats the code of the modified java files using `google-java-format`.
+
+### Advanced pre-commit pipeline hook
+If you wish to modify the output of the pre-commit hook, you can set the `preCommitHookPipeline` configuration.
+
+To completely ignore the hook output, you could use the following configuration:
+```xml
+      <configuration>
+        <preCommitHookPipeline>&gt;/dev/null</preCommitHookPipeline>
+      </configuration>
+```
+
+To display error lines from the maven output and fail build with any errors, you could use the following configuration:
+```xml
+      <configuration>
+        <preCommitHookPipeline>| grep -F '[ERROR]' || exit 0 &amp;&amp; exit 1</preCommitHookPipeline>
+      </configuration>
+```

--- a/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -52,7 +52,7 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
   @Parameter(property = "debug", defaultValue = "false")
   private boolean debug;
 
-  /** Make the pre-commit hook quiet */
+  /** Add pipeline to process the results of the pre-commit hook.  Exit non-zero to prevent the commit */
   @Parameter(property = "preCommitHookPipeline", defaultValue = "")
   private String preCommitHookPipeline;
 

--- a/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -1,13 +1,10 @@
 package com.cosium.code.format;
 
+import static java.util.Optional.ofNullable;
+
 import com.cosium.code.format.executable.Executable;
 import com.cosium.code.format.executable.ExecutableManager;
 import com.cosium.code.format.maven.MavenEnvironment;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -15,8 +12,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Optional.ofNullable;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Installs git hooks on each initialization. Hooks are always overriden in case changes in:
@@ -52,6 +51,10 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
 
   @Parameter(property = "debug", defaultValue = "false")
   private boolean debug;
+
+  /** Make the pre-commit hook quiet */
+  @Parameter(property = "quiet", defaultValue = "false")
+  private boolean quiet;
 
   public void execute() throws MojoExecutionException {
     if (!isExecutionRoot()) {
@@ -107,8 +110,11 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
             .filter(prop -> System.getProperty(prop) != null)
             .map(prop -> "-D" + prop + "=" + System.getProperty(prop));
 
-    return Stream.concat(propagatedProperties, Stream.of(propertiesToAdd))
-        .collect(Collectors.joining(" "));
+    Stream<String> properties = Stream.concat(propagatedProperties, Stream.of(propertiesToAdd));
+    if (quiet) {
+      properties = Stream.concat(properties, Stream.of(">/dev/null"));
+    }
+    return properties.collect(Collectors.joining(" "));
   }
 
   private Path prepareHooksDirectory() {

--- a/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -53,8 +53,8 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
   private boolean debug;
 
   /** Make the pre-commit hook quiet */
-  @Parameter(property = "quiet", defaultValue = "false")
-  private boolean quiet;
+  @Parameter(property = "preCommitHookPipeline", defaultValue = "")
+  private String preCommitHookPipeline;
 
   public void execute() throws MojoExecutionException {
     if (!isExecutionRoot()) {
@@ -111,8 +111,8 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
             .map(prop -> "-D" + prop + "=" + System.getProperty(prop));
 
     Stream<String> properties = Stream.concat(propagatedProperties, Stream.of(propertiesToAdd));
-    if (quiet) {
-      properties = Stream.concat(properties, Stream.of(">/dev/null"));
+    if (preCommitHookPipeline != null && !preCommitHookPipeline.isEmpty()) {
+      properties = Stream.concat(properties, Stream.of(preCommitHookPipeline));
     }
     return properties.collect(Collectors.joining(" "));
   }

--- a/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
+++ b/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-%s -f %s git-code-format:on-pre-commit %s
+%s -f %s com.cosium.code:maven-git-code-format:on-pre-commit %s

--- a/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
+++ b/src/main/resources/com/cosium/code/format/maven-git-code-format.pre-commit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-%s -f %s com.cosium.code:maven-git-code-format:on-pre-commit %s
+%s -f %s git-code-format:on-pre-commit %s


### PR DESCRIPTION
setting quiet to true will quiet pre-commit hook
added example profile that executes install-hooks only when pre-commit file is missing
